### PR TITLE
♻️ Robustify worker

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 process-engine.io
+Copyright (c) 2017-2019 http://www.process-engine.io
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/external_task_api_client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -14,8 +14,6 @@ import {
 
 export class ExternalTaskApiExternalAccessor implements IExternalTaskApi {
 
-  public config: any;
-
   private baseUrl = 'api/external_task/v1';
 
   private httpClient: IHttpClient = undefined;

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -98,7 +98,13 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
   }
 
   private async extendLocks<TPayload>(identity: IIdentity, externalTask: ExternalTask<TPayload>): Promise<void> {
-    await this.externalTaskApi.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
+    try {
+      await this.externalTaskApi.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
+    } catch (error) {
+      // This can happen, if the lock-extension was performed after the task was already finished.
+      // Since this isn't really an error, a warning suffices here.
+      logger.warn(`An error occured while trying to extend the lock for ExternalTask ${externalTask.id}`, error);
+    }
   }
 
   private async sleep(milliseconds: number): Promise<void> {

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -74,8 +74,8 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
 
       logger.error(
         'An error occured during fetchAndLock!',
-        'This can happen, if the tasks were already locked by another worker, before this worker could apply its own lock.',
-        error,
+        error.message,
+        error.stack,
       );
 
       // Returning an empty Array here, since "waitForAndHandle" already implements a timeout, in case no tasks are available for processing.
@@ -112,7 +112,7 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
     } catch (error) {
       // This can happen, if the lock-extension was performed after the task was already finished.
       // Since this isn't really an error, a warning suffices here.
-      logger.warn(`An error occured while trying to extend the lock for ExternalTask ${externalTask.id}`, error);
+      logger.warn(`An error occured while trying to extend the lock for ExternalTask ${externalTask.id}`, error.message, error.stack);
     }
   }
 

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -91,7 +91,8 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
   ): Promise<void> {
 
     try {
-      const interval = setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - 5000);
+      const lockExtensionBuffer = 5000;
+      const interval = setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
       const result = await handleAction(externalTask);
       clearInterval(interval);
 

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -44,6 +44,10 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
         longpollingTimeout,
       );
 
+      if (externalTasks.length === 0) {
+        continue;
+      }
+
       const interval = setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTasks), this.lockDuration - 5000);
 
       const executeTaskPromises: Array<Promise<void>> = [];

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -75,7 +75,8 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
       logger.error(
         'An error occured during fetchAndLock!',
         'This can happen, if the tasks were already locked by another worker, before this worker could apply its own lock.',
-        error);
+        error,
+      );
 
       // Returning an empty Array here, since "waitForAndHandle" already implements a timeout, in case no tasks are available for processing.
       // No need to do that twice.
@@ -91,7 +92,10 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
 
     try {
       const lockExtensionBuffer = 5000;
-      const interval = setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
+
+      const interval =
+        setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
+
       const result = await handleAction(externalTask);
       clearInterval(interval);
 

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -72,7 +72,10 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
         .fetchAndLockExternalTasks<TPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
     } catch (error) {
 
-      logger.error(error);
+      logger.error(
+        'An error occured during fetchAndLock!',
+        'This can happen, if the tasks were already locked by another worker, before this worker could apply its own lock.',
+        error);
       await this.sleep(1000);
 
       return this.fetchAndLockExternalTasks<TPayload>(identity, topic, maxTasks, longpollingTimeout);
@@ -92,7 +95,7 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
 
       await result.sendToExternalTaskApi(this.externalTaskApi, identity, this.workerId);
     } catch (error) {
-      logger.error(error);
+      logger.error('Failed to execute ExternalTask!', error);
       await this.externalTaskApi.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
     }
   }

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -76,9 +76,11 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
         'An error occured during fetchAndLock!',
         'This can happen, if the tasks were already locked by another worker, before this worker could apply its own lock.',
         error);
-      await this.sleep(1000);
 
-      return this.fetchAndLockExternalTasks<TPayload>(identity, topic, maxTasks, longpollingTimeout);
+      // Returning an empty Array here, since "waitForAndHandle" already implements a timeout,
+      // if no results are available for processing.
+      // No need to do that twice.
+      return [];
     }
   }
 

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -77,8 +77,7 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
         'This can happen, if the tasks were already locked by another worker, before this worker could apply its own lock.',
         error);
 
-      // Returning an empty Array here, since "waitForAndHandle" already implements a timeout,
-      // if no results are available for processing.
+      // Returning an empty Array here, since "waitForAndHandle" already implements a timeout, in case no tasks are available for processing.
       // No need to do that twice.
       return [];
     }

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -45,6 +45,7 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
       );
 
       if (externalTasks.length === 0) {
+        await this.sleep(1000);
         continue;
       }
 


### PR DESCRIPTION
## Changes

Refactor the worker:
1. Apply long-polling timeout, if fetchAndLock didn't return anything, to avoid request-spamming against the ProcessEngine.
2. Move Lock-Extension to the execution function to avoid request overlays between extending the lock for an ExternalTask and finishing it.
3. Improve logging verbosity to get more meaningful log messages.
4. Intercept lock-extension errors and treat them as a warning (such errors usually only happen when the scenario described in 2. happens, which is not really an error).
5. Remove duplicated retry from `fetchAndLockExternalTasks`, since that is already covered by the loop.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/343

PR: #12

## How to test the changes

Kinda hard to test, as this is pretty much a fix for a race condition. 
You'll need to set up several ExternalTask workers that repeatedly poll against the ProcessEngine and perform long-running tasks.

If everything goes as intended, there shouldn't be any errors as described in the referenced issue.
