### PR TITLE
Fix error in too many parameter by calling ExternalTaskApiClientServi…

### DIFF
--- a/python/external_task_api_client/ExternalTaskResults/bpmn_error.py
+++ b/python/external_task_api_client/ExternalTaskResults/bpmn_error.py
@@ -5,11 +5,9 @@ class ExternalTaskBpmnError:
         self.__error_details = error_details
 
     async def send_to_external_task_api(self, external_task_api, identity, worker_id):
-        await external_task_api
-            .handle_bpmn_error(
+        await external_task_api.handle_bpmn_error(
                 identity,
                 worker_id,
                 self.__external_task_id,
-                self.__error_message,
-                self.__error_details
+                self.__error_message
             )


### PR DESCRIPTION
…ce.handle_bpmn_error only with 5 parameters

