### PR TITLE
 ♻️ Make ExternalTaskWorker immutable

### DIFF
--- a/dotnet/src/ExternalTaskApiClientService.cs
+++ b/dotnet/src/ExternalTaskApiClientService.cs
@@ -12,9 +12,10 @@
 
     using EssentialProjects.IAM.Contracts;
 
-    using ProcessEngine.ExternalTaskAPI.Contracts;
+    using ProcessEngine.ConsumerAPI.Contracts.APIs;
+    using ProcessEngine.ConsumerAPI.Contracts.DataModel;
 
-    public class ExternalTaskApiClientService : IExternalTaskAPI
+    public class ExternalTaskApiClientService : IExternalTaskConsumerApi
     {
         private readonly HttpClient httpClient;
 

--- a/dotnet/src/ExternalTaskWorker.cs
+++ b/dotnet/src/ExternalTaskWorker.cs
@@ -15,7 +15,7 @@ namespace ProcessEngine.ExternalTaskAPI.Client
     /// <summary>
     /// Periodically fetches, locks and processes ExternalTasks for a given topic.
     /// </summary>
-    public class ExternalTaskWorker<TExternalTaskPayload> : IExternalTaskWorker<TExternalTaskPayload>
+    public class ExternalTaskWorker<TExternalTaskPayload, TResultPayload> : IExternalTaskWorker
             where TExternalTaskPayload : new()
     {
         private const int LockDuration = 30000;
@@ -24,7 +24,7 @@ namespace ProcessEngine.ExternalTaskAPI.Client
         private readonly string Topic;
         private readonly int MaxTasks;
         private readonly int LongpollingTimeout;
-        private readonly HandleExternalTaskAction<TExternalTaskPayload> ProcessingFunction;
+        private readonly HandleExternalTaskAction<TExternalTaskPayload, TResultPayload> ProcessingFunction;
 
         private ExternalTaskApiClientService ExternalTaskClient;
 
@@ -37,7 +37,7 @@ namespace ProcessEngine.ExternalTaskAPI.Client
             string topic,
             int maxTasks,
             int longpollingTimeout,
-            HandleExternalTaskAction<TExternalTaskPayload> processingFunction
+            HandleExternalTaskAction<TExternalTaskPayload, TResultPayload> processingFunction
         )
         {
             this.ProcessEngineUrl = processEngineUrl;
@@ -47,7 +47,7 @@ namespace ProcessEngine.ExternalTaskAPI.Client
             this.LongpollingTimeout = longpollingTimeout;
             this.ProcessingFunction = processingFunction;
 
-            this.initialize();
+            this.Initialize();
         }
 
         /// <summary>
@@ -60,16 +60,16 @@ namespace ProcessEngine.ExternalTaskAPI.Client
         /// </summary>
         public string WorkerId { get; } = Guid.NewGuid().ToString();
 
-        public void start() {
+        public void Start() {
             this.PollingActive = true;
             this.ProcessExternalTasks();
         }
 
-        public void stop() {
+        public void Stop() {
             this.PollingActive = false;
         }
 
-        private void initialize() {
+        private void Initialize() {
           var httpClient = new HttpClient();
           httpClient.BaseAddress = new Uri(ProcessEngineUrl);
 

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -20,7 +20,7 @@
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="ProcessEngine.ExternalTaskAPI.Contracts" Version="6.0.0" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-make-external-task-worker-immutable" />
     </ItemGroup>
 
 </Project>

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>2.0.0</Version>
+        <Version>3.0.0</Version>
         <RootNamespace>ProcessEngine.ExternalTaskAPI.Client</RootNamespace>
         <AssemblyName>ProcessEngine.ExternalTaskAPI.Client</AssemblyName>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -15,11 +15,12 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>ExternalTaskAPI;5Minds</PackageTags>
         <PackageLicenseUrl />
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
-        <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
         <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-make-external-task-worker-immutable" />
     </ItemGroup>
 

--- a/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-        <PackageReference Include="ProcessEngine.ExternalTaskAPI.Contracts" Version="6.0.0" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0-feature-make-external-task-worker-immutable" />
     </ItemGroup>
 
 </Project>

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
+    "@process-engine/consumer_api_contracts": "8.1.0-c1903190-b30",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "uuid": "^3.3.2"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,7 +21,7 @@
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "8.1.0-35fc9279-b29",
+    "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "uuid": "^3.3.2"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@essential-projects/errors_ts": "^1.4.0",
     "@essential-projects/http_contracts": "^2.3.0",
+    "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.4.0",
     "@process-engine/consumer_api_contracts": "feature~make_external_task_worker_immutable",
     "async-middleware": "^1.2.1",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/external_task_api_client",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -15,7 +15,7 @@ import {ExternalTaskApiClientService} from './external_task_api_client_service';
 
 const logger: Logger = Logger.createLogger('processengine:external_task:worker');
 
-export class ExternalTaskWorker<TExternalTaskPayload> implements IExternalTaskWorker {
+export class ExternalTaskWorker<TExternalTaskPayload, TResultPayload> implements IExternalTaskWorker {
 
   private readonly _workerId = uuid.v4();
   private readonly lockDuration = 30000;
@@ -24,7 +24,7 @@ export class ExternalTaskWorker<TExternalTaskPayload> implements IExternalTaskWo
   private readonly topic: string;
   private readonly maxTasks: number;
   private readonly longpollingTimeout: number;
-  private readonly processingFunction: HandleExternalTaskAction<TExternalTaskPayload>;
+  private readonly processingFunction: HandleExternalTaskAction<TExternalTaskPayload, TResultPayload>;
 
   private _pollingActive: boolean = false;
   private externalTaskClient: ExternalTaskApiClientService;
@@ -35,7 +35,7 @@ export class ExternalTaskWorker<TExternalTaskPayload> implements IExternalTaskWo
     topic: string,
     maxTasks: number,
     longpollingTimeout: number,
-    processingFunction: HandleExternalTaskAction<TExternalTaskPayload>,
+    processingFunction: HandleExternalTaskAction<TExternalTaskPayload, TResultPayload>,
   ) {
     this.processEngineUrl = processEngineUrl;
     this.identity = identity;
@@ -142,7 +142,7 @@ export class ExternalTaskWorker<TExternalTaskPayload> implements IExternalTaskWo
       } else if (result instanceof DataModels.ExternalTask.ExternalTaskServiceError) {
         await this.externalTaskClient.handleServiceError(identity, this.workerId, externalTask.id, result.errorMessage, result.errorDetails);
       } else {
-        const resultAsSuccess = result as DataModels.ExternalTask.ExternalTaskSuccessResult<TExternalTaskPayload>;
+        const resultAsSuccess = result as DataModels.ExternalTask.ExternalTaskSuccessResult;
 
         await this
           .externalTaskClient

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -1,47 +1,86 @@
+/* eslint-disable @typescript-eslint/member-naming */
 import {Logger} from 'loggerhythm';
 import * as uuid from 'uuid';
 
+import {HttpClient} from '@essential-projects/http';
 import {IIdentity} from '@essential-projects/iam_contracts';
 import {
-  APIs,
   DataModels,
   HandleExternalTaskAction,
   IExternalTaskWorker,
 } from '@process-engine/consumer_api_contracts';
 
+import {ExternalTaskApiExternalAccessor} from './accessors/external_accessor';
+import {ExternalTaskApiClientService} from './external_task_api_client_service';
+
 const logger: Logger = Logger.createLogger('processengine:external_task:worker');
 
-export class ExternalTaskWorker implements IExternalTaskWorker {
+export class ExternalTaskWorker<TExternalTaskPayload> implements IExternalTaskWorker {
 
-  // eslint-disable-next-line @typescript-eslint/member-naming
   private readonly _workerId = uuid.v4();
   private readonly lockDuration = 30000;
-  private readonly externalTaskApi: APIs.IExternalTaskConsumerApi = undefined;
+  private readonly processEngineUrl: string;
+  private readonly identity: IIdentity;
+  private readonly topic: string;
+  private readonly maxTasks: number;
+  private readonly longpollingTimeout: number;
+  private readonly processingFunction: HandleExternalTaskAction<TExternalTaskPayload>;
 
-  constructor(externalTaskApi: APIs.IExternalTaskConsumerApi) {
-    this.externalTaskApi = externalTaskApi;
+  private _pollingActive: boolean = false;
+  private externalTaskClient: ExternalTaskApiClientService;
+
+  constructor(
+    processEngineUrl: string,
+    identity: IIdentity,
+    topic: string,
+    maxTasks: number,
+    longpollingTimeout: number,
+    processingFunction: HandleExternalTaskAction<TExternalTaskPayload>,
+  ) {
+    this.processEngineUrl = processEngineUrl;
+    this.identity = identity;
+    this.topic = topic;
+    this.maxTasks = maxTasks;
+    this.longpollingTimeout = longpollingTimeout;
+    this.processingFunction = processingFunction;
+
+    this.initialize();
   }
 
   public get workerId(): string {
     return this._workerId;
   }
 
-  public async waitForAndHandle<TPayload>(
-    identity: IIdentity,
-    topic: string,
-    maxTasks: number,
-    longpollingTimeout: number,
-    handleAction: HandleExternalTaskAction<TPayload>,
-  ): Promise<void> {
+  public get pollingIsActive(): boolean {
+    return this._pollingActive;
+  }
 
-    const keepPolling = true;
-    while (keepPolling) {
+  public start(): void {
+    this._pollingActive = true;
+    this.processExternalTasks();
+  }
 
-      const externalTasks = await this.fetchAndLockExternalTasks<TPayload>(
-        identity,
-        topic,
-        maxTasks,
-        longpollingTimeout,
+  public stop(): void {
+    this._pollingActive = false;
+  }
+
+  private initialize(): void {
+    const httpClient = new HttpClient();
+    httpClient.config = {url: this.processEngineUrl};
+
+    const externalAccessor = new ExternalTaskApiExternalAccessor(httpClient);
+    this.externalTaskClient = new ExternalTaskApiClientService(externalAccessor);
+  }
+
+  private async processExternalTasks(): Promise<void> {
+
+    while (this.pollingIsActive) {
+
+      const externalTasks = await this.fetchAndLockExternalTasks(
+        this.identity,
+        this.topic,
+        this.maxTasks,
+        this.longpollingTimeout,
       );
 
       if (externalTasks.length === 0) {
@@ -52,24 +91,24 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
       const executeTaskPromises: Array<Promise<void>> = [];
 
       for (const externalTask of externalTasks) {
-        executeTaskPromises.push(this.executeExternalTask(identity, externalTask, handleAction));
+        executeTaskPromises.push(this.executeExternalTask(this.identity, externalTask));
       }
 
       await Promise.all(executeTaskPromises);
     }
   }
 
-  private async fetchAndLockExternalTasks<TPayload>(
+  private async fetchAndLockExternalTasks(
     identity: IIdentity,
     topic: string,
     maxTasks: number,
     longpollingTimeout: number,
-  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TPayload>>> {
+  ): Promise<Array<DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>>> {
 
     try {
       return await this
-        .externalTaskApi
-        .fetchAndLockExternalTasks<TPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
+        .externalTaskClient
+        .fetchAndLockExternalTasks<TExternalTaskPayload>(identity, this.workerId, topic, maxTasks, longpollingTimeout, this.lockDuration);
     } catch (error) {
 
       logger.error(
@@ -84,42 +123,41 @@ export class ExternalTaskWorker implements IExternalTaskWorker {
     }
   }
 
-  private async executeExternalTask<TPayload>(
+  private async executeExternalTask(
     identity: IIdentity,
-    externalTask: DataModels.ExternalTask.ExternalTask<TPayload>,
-    handleAction: HandleExternalTaskAction<TPayload>,
+    externalTask: DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>,
   ): Promise<void> {
 
     try {
       const lockExtensionBuffer = 5000;
 
       const interval =
-        setInterval(async (): Promise<void> => this.extendLocks<TPayload>(identity, externalTask), this.lockDuration - lockExtensionBuffer);
+        setInterval(async (): Promise<void> => this.extendLocks(identity, externalTask), this.lockDuration - lockExtensionBuffer);
 
-      const result = await handleAction(externalTask);
+      const result = await this.processingFunction(externalTask);
       clearInterval(interval);
 
       if (result instanceof DataModels.ExternalTask.ExternalTaskBpmnError) {
-        await this.externalTaskApi.handleBpmnError(identity, this.workerId, externalTask.id, result.errorCode);
+        await this.externalTaskClient.handleBpmnError(identity, this.workerId, externalTask.id, result.errorCode);
       } else if (result instanceof DataModels.ExternalTask.ExternalTaskServiceError) {
-        await this.externalTaskApi.handleServiceError(identity, this.workerId, externalTask.id, result.errorMessage, result.errorDetails);
+        await this.externalTaskClient.handleServiceError(identity, this.workerId, externalTask.id, result.errorMessage, result.errorDetails);
       } else {
-        const resultAsSuccess = result as DataModels.ExternalTask.ExternalTaskSuccessResult<TPayload>;
+        const resultAsSuccess = result as DataModels.ExternalTask.ExternalTaskSuccessResult<TExternalTaskPayload>;
 
         await this
-          .externalTaskApi
+          .externalTaskClient
           .finishExternalTask(identity, this.workerId, externalTask.id, resultAsSuccess.result);
       }
 
     } catch (error) {
       logger.error('Failed to execute ExternalTask!', error.message, error.stack);
-      await this.externalTaskApi.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
+      await this.externalTaskClient.handleServiceError(identity, this.workerId, externalTask.id, error.message, '');
     }
   }
 
-  private async extendLocks<TPayload>(identity: IIdentity, externalTask: DataModels.ExternalTask.ExternalTask<TPayload>): Promise<void> {
+  private async extendLocks(identity: IIdentity, externalTask: DataModels.ExternalTask.ExternalTask<TExternalTaskPayload>): Promise<void> {
     try {
-      await this.externalTaskApi.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
+      await this.externalTaskClient.extendLock(identity, this.workerId, externalTask.id, this.lockDuration);
     } catch (error) {
       // This can happen, if the lock-extension was performed after the task was already finished.
       // Since this isn't really an error, a warning suffices here.


### PR DESCRIPTION
## Changes
 
1. Replace `waitForHandle` with `start/stop` pattern
2. Expect all essential parameters to be passed through the constructor
    - This will ensure that a single worker can only process a single topic; as it was meant to be
3. Expect two type parameters for worker class: 
    - `TExternalTaskPayload`: The type of the ExternalTask's payload
    - `TResultPayload`: The type of result's payload
4. Move all initialization of subdependencies (i.e. ExternalTaskApIClient and ExternalAccessor) into the ExternalTaskWorker.
    - The user now only needs to pass the url to the ProcessEngine. All initialization is handled by the worker itself now

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/410

PR: #23