### PR TITLE
♻️ Make ExternalTaskWorker identity exchangable

### DIFF
--- a/dotnet/src/ExternalTaskWorker.cs
+++ b/dotnet/src/ExternalTaskWorker.cs
@@ -20,7 +20,6 @@ namespace ProcessEngine.ExternalTaskAPI.Client
     {
         private const int LockDuration = 30000;
         private readonly string ProcessEngineUrl;
-        private readonly IIdentity Identity;
         private readonly string Topic;
         private readonly int MaxTasks;
         private readonly int LongpollingTimeout;
@@ -49,6 +48,12 @@ namespace ProcessEngine.ExternalTaskAPI.Client
 
             this.Initialize();
         }
+
+        /// <summary>
+        /// The identity the worker should use to poll for ExternalTasks.
+        /// </summary>
+        /// <value></value>
+        public IIdentity Identity { get; set;}
 
         /// <summary>
         /// Indicates, if the worker is currently polling for ExternalTasks.

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>3.0.0</Version>
+        <Version>3.1.0</Version>
         <RootNamespace>ProcessEngine.ExternalTaskAPI.Client</RootNamespace>
         <AssemblyName>ProcessEngine.ExternalTaskAPI.Client</AssemblyName>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/external_task_api_client",
-  "version": "2.0.0-alpha.10",
+  "version": "2.1.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/src/external_task_worker.ts
+++ b/typescript/src/external_task_worker.ts
@@ -20,12 +20,12 @@ export class ExternalTaskWorker<TExternalTaskPayload, TResultPayload> implements
   private readonly _workerId = uuid.v4();
   private readonly lockDuration = 30000;
   private readonly processEngineUrl: string;
-  private readonly identity: IIdentity;
   private readonly topic: string;
   private readonly maxTasks: number;
   private readonly longpollingTimeout: number;
   private readonly processingFunction: HandleExternalTaskAction<TExternalTaskPayload, TResultPayload>;
 
+  private _identity: IIdentity;
   private _pollingActive: boolean = false;
   private externalTaskClient: ExternalTaskApiClientService;
 
@@ -45,6 +45,14 @@ export class ExternalTaskWorker<TExternalTaskPayload, TResultPayload> implements
     this.processingFunction = processingFunction;
 
     this.initialize();
+  }
+
+  public get identity(): IIdentity {
+    return this._identity;
+  }
+
+  public set identity(value: IIdentity) {
+    this._identity = value;
   }
 
   public get workerId(): string {


### PR DESCRIPTION
## Changes

Make the ExternalTaskWorker's identity exchangable.

## Issues

PR: #24

## How to test the changes

- Create an ExternalTaskWorker instance with an identity
- Poll for ExternalTasks
- See that the polling is done with the first identity
- Assign a new identity to `ExternalTaskWorker.identity`
- Poll again
- See that the new identity is used