### PR TITLE
🐛 Fix handling of customized ExternalTaskErrors

### DIFF
--- a/dotnet/src/ExternalTaskApiClientService.cs
+++ b/dotnet/src/ExternalTaskApiClientService.cs
@@ -90,6 +90,20 @@
             await this.SendPostToExternalTaskApi(identity, uri, request);
         }
 
+        public async Task HandleBpmnError(IIdentity identity, string workerId, string externalTaskId, string errorCode, string errorMessage)
+        {
+            var uri = $"task/{externalTaskId}/handle_bpmn_error";
+
+            var request = new HandleBpmnErrorRequest
+            (
+                workerId,
+                errorCode,
+                errorMessage
+            );
+
+            await this.SendPostToExternalTaskApi(identity, uri, request);
+        }
+
         public async Task HandleServiceError(IIdentity identity, string workerId, string externalTaskId, string errorMessage, string errorDetails)
         {
             var uri = $"task/{externalTaskId}/handle_service_error";
@@ -99,6 +113,21 @@
                 workerId,
                 errorMessage,
                 errorDetails
+            );
+
+            await this.SendPostToExternalTaskApi(identity, uri, request);
+        }
+
+        public async Task HandleServiceError(IIdentity identity, string workerId, string externalTaskId, string errorMessage, string errorDetails, string errorCode)
+        {
+            var uri = $"task/{externalTaskId}/handle_service_error";
+
+            var request = new HandleServiceErrorRequest
+            (
+                workerId,
+                errorMessage,
+                errorDetails,
+                errorCode
             );
 
             await this.SendPostToExternalTaskApi(identity, uri, request);

--- a/dotnet/src/ExternalTaskWorker.cs
+++ b/dotnet/src/ExternalTaskWorker.cs
@@ -195,7 +195,7 @@ namespace ProcessEngine.ExternalTaskAPI.Client
             if (result is ExternalTaskBpmnError) {
 
                 var bpmnError = result as ExternalTaskBpmnError;
-                await this.ExternalTaskClient.HandleBpmnError(identity, this.WorkerId, externalTaskId, bpmnError.errorCode);
+                await this.ExternalTaskClient.HandleBpmnError(identity, this.WorkerId, externalTaskId, bpmnError.ErrorCode);
 
             }
             else if (result is ExternalTaskServiceError<object>)
@@ -204,12 +204,12 @@ namespace ProcessEngine.ExternalTaskAPI.Client
                 var serviceError = result as ExternalTaskServiceError<object>;
                 await this
                     .ExternalTaskClient
-                    .HandleServiceError(identity, this.WorkerId, externalTaskId, serviceError.errorMessage, serviceError.errorDetails as string);
+                    .HandleServiceError(identity, this.WorkerId, externalTaskId, serviceError.ErrorMessage, serviceError.ErrorDetails as string);
 
             }
             else
             {
-                await this.ExternalTaskClient.FinishExternalTask(identity, this.WorkerId, externalTaskId, (result as ExternalTaskSuccessResult<object>).result);
+                await this.ExternalTaskClient.FinishExternalTask(identity, this.WorkerId, externalTaskId, (result as ExternalTaskSuccessResult<object>).Result);
             }
         }
     }

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-feature-add-optional-message-to-bpmn-error-type" />
     </ItemGroup>
 
 </Project>

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Version>3.1.0</Version>
+        <Version>3.2.0</Version>
         <RootNamespace>ProcessEngine.ExternalTaskAPI.Client</RootNamespace>
         <AssemblyName>ProcessEngine.ExternalTaskAPI.Client</AssemblyName>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
+++ b/dotnet/src/ProcessEngine.ExternalTaskAPI.Client.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-feature-add-optional-message-to-bpmn-error-type" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-develop" />
     </ItemGroup>
 
 </Project>

--- a/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="xunit" Version="2.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-feature-add-optional-message-to-bpmn-error-type" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-develop" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 

--- a/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
+++ b/dotnet/tests/ProcessEngine.ExternalTaskAPI.Client.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="xunit" Version="2.3.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
         <PackageReference Include="EssentialProjects.IAM.Contracts" Version="0.1.3" />
-        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.1.0" />
+        <PackageReference Include="ProcessEngine.ConsumerAPI.Contracts" Version="14.3.0-feature-add-optional-message-to-bpmn-error-type" />
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/external_task_api_client",
-  "version": "2.2.0-alpha.1",
+  "version": "2.2.0",
   "description": "the api-client package for process-engine-consumer",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "^9.1.0",
+    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "uuid": "^3.3.2"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -22,7 +22,7 @@
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/http": "^2.4.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/consumer_api_contracts": "feature~add_optional_message_to_bpmn_error_type",
+    "@process-engine/consumer_api_contracts": "9.2.0-alpha.1",
     "async-middleware": "^1.2.1",
     "loggerhythm": "^3.0.3",
     "uuid": "^3.3.2"

--- a/typescript/src/accessors/external_accessor.ts
+++ b/typescript/src/accessors/external_accessor.ts
@@ -55,7 +55,13 @@ export class ExternalTaskApiExternalAccessor implements APIs.IExternalTaskConsum
     await this.httpClient.post<DataModels.ExternalTask.ExtendLockRequestPayload, void>(url, payload, requestAuthHeaders);
   }
 
-  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
+  public async handleBpmnError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorCode: string,
+    errorMessage?: string,
+  ): Promise<void> {
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
 
@@ -64,7 +70,7 @@ export class ExternalTaskApiExternalAccessor implements APIs.IExternalTaskConsum
 
     url = this.applyBaseUrl(url);
 
-    const payload = new DataModels.ExternalTask.HandleBpmnErrorRequestPayload(workerId, errorCode);
+    const payload = new DataModels.ExternalTask.HandleBpmnErrorRequestPayload(workerId, errorCode, errorMessage);
 
     await this.httpClient.post<DataModels.ExternalTask.HandleBpmnErrorRequestPayload, void>(url, payload, requestAuthHeaders);
   }
@@ -75,6 +81,7 @@ export class ExternalTaskApiExternalAccessor implements APIs.IExternalTaskConsum
     externalTaskId: string,
     errorMessage: string,
     errorDetails: string,
+    errorCode?: string,
   ): Promise<void> {
 
     const requestAuthHeaders = this.createRequestAuthHeaders(identity);
@@ -84,7 +91,7 @@ export class ExternalTaskApiExternalAccessor implements APIs.IExternalTaskConsum
 
     url = this.applyBaseUrl(url);
 
-    const payload = new DataModels.ExternalTask.HandleServiceErrorRequestPayload(workerId, errorMessage, errorDetails);
+    const payload = new DataModels.ExternalTask.HandleServiceErrorRequestPayload(workerId, errorMessage, errorDetails, errorCode);
 
     await this.httpClient.post<DataModels.ExternalTask.HandleServiceErrorRequestPayload, void>(url, payload, requestAuthHeaders);
   }

--- a/typescript/src/accessors/internal_accessor.ts
+++ b/typescript/src/accessors/internal_accessor.ts
@@ -37,11 +37,15 @@ export class ExternalTaskApiInternalAccessor implements APIs.IExternalTaskConsum
     return this.externalApiService.extendLock(identity, workerId, externalTaskId, additionalDuration);
   }
 
-  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
-
+  public async handleBpmnError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorCode: string,
+    errorMessage?: string,
+  ): Promise<void> {
     this.ensureIsAuthorized(identity);
-
-    return this.externalApiService.handleBpmnError(identity, workerId, externalTaskId, errorCode);
+    return this.externalApiService.handleBpmnError(identity, workerId, externalTaskId, errorCode, errorMessage);
   }
 
   public async handleServiceError(
@@ -50,11 +54,10 @@ export class ExternalTaskApiInternalAccessor implements APIs.IExternalTaskConsum
     externalTaskId: string,
     errorMessage: string,
     errorDetails: string,
+    errorCode?: string,
   ): Promise<void> {
-
     this.ensureIsAuthorized(identity);
-
-    return this.externalApiService.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails);
+    return this.externalApiService.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails, errorCode);
   }
 
   public async finishExternalTask<TResultType>(

--- a/typescript/src/external_task_api_client_service.ts
+++ b/typescript/src/external_task_api_client_service.ts
@@ -30,8 +30,14 @@ export class ExternalTaskApiClientService implements APIs.IExternalTaskConsumerA
     return this.externalApiAccessor.extendLock(identity, workerId, externalTaskId, additionalDuration);
   }
 
-  public async handleBpmnError(identity: IIdentity, workerId: string, externalTaskId: string, errorCode: string): Promise<void> {
-    return this.externalApiAccessor.handleBpmnError(identity, workerId, externalTaskId, errorCode);
+  public async handleBpmnError(
+    identity: IIdentity,
+    workerId: string,
+    externalTaskId: string,
+    errorCode: string,
+    errorMessage?: string,
+  ): Promise<void> {
+    return this.externalApiAccessor.handleBpmnError(identity, workerId, externalTaskId, errorCode, errorMessage);
   }
 
   public async handleServiceError(
@@ -40,8 +46,9 @@ export class ExternalTaskApiClientService implements APIs.IExternalTaskConsumerA
     externalTaskId: string,
     errorMessage: string,
     errorDetails: string,
+    errorCode?: string,
   ): Promise<void> {
-    return this.externalApiAccessor.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails);
+    return this.externalApiAccessor.handleServiceError(identity, workerId, externalTaskId, errorMessage, errorDetails, errorCode);
   }
 
   public async finishExternalTask<TResultType>(identity: IIdentity, workerId: string, externalTaskId: string, payload: TResultType): Promise<void> {


### PR DESCRIPTION
## Changes (both .NET and .ts)

1. Account for `errorMessage` and `errorCode` properties in ExternalTask requests
2. Fix some reference errors (.NET only)

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/493

PR: #27

## How to test the changes

- Run a Process that uses ExternalTasks with ErrorBoundaryEvents
- Provoke an error that can be intercepted by the BoundaryEvent
- See that it works